### PR TITLE
seralize Path/PathBuf as &str/String for wasm32

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1356,7 +1356,7 @@ array! {
 }
 
 impl Encodable for path::Path {
-    #[cfg(target_os = "redox")]
+    #[cfg(any(target_os = "redox", target_arch = "wasm32"))]
     fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
         self.as_os_str().to_str().unwrap().encode(e)
     }
@@ -1380,7 +1380,7 @@ impl Encodable for path::PathBuf {
 }
 
 impl Decodable for path::PathBuf {
-    #[cfg(target_os = "redox")]
+    #[cfg(any(target_os = "redox", target_arch = "wasm32"))]
     fn decode<D: Decoder>(d: &mut D) -> Result<path::PathBuf, D::Error> {
         let string: String = try!(Decodable::decode(d));
         let s: OsString = OsString::from(string);


### PR DESCRIPTION
Hopefully a sensible strategy to get wasm32 to work for those crates that still depend on rustc-serialize.