### PR TITLE
Various compat changes for recent rusts

### DIFF
--- a/src/collection_impls.rs
+++ b/src/collection_impls.rs
@@ -21,7 +21,7 @@ impl<
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_seq(self.len(), |s| {
             for (i, e) in self.iter().enumerate() {
-                try!(s.emit_seq_elt(i, |s| e.encode(s)));
+                s.emit_seq_elt(i, |s| e.encode(s))?;
             }
             Ok(())
         })
@@ -33,7 +33,7 @@ impl<T:Decodable> Decodable for LinkedList<T> {
         d.read_seq(|d, len| {
             let mut list = LinkedList::new();
             for i in 0..len {
-                list.push_back(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
+                list.push_back(d.read_seq_elt(i, |d| Decodable::decode(d))?);
             }
             Ok(list)
         })
@@ -44,7 +44,7 @@ impl<T: Encodable> Encodable for VecDeque<T> {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_seq(self.len(), |s| {
             for (i, e) in self.iter().enumerate() {
-                try!(s.emit_seq_elt(i, |s| e.encode(s)));
+                s.emit_seq_elt(i, |s| e.encode(s))?;
             }
             Ok(())
         })
@@ -56,7 +56,7 @@ impl<T:Decodable> Decodable for VecDeque<T> {
         d.read_seq(|d, len| {
             let mut deque: VecDeque<T> = VecDeque::new();
             for i in 0..len {
-                deque.push_back(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
+                deque.push_back(d.read_seq_elt(i, |d| Decodable::decode(d))?);
             }
             Ok(deque)
         })
@@ -71,8 +71,8 @@ impl<
         e.emit_map(self.len(), |e| {
             let mut i = 0;
             for (key, val) in self.iter() {
-                try!(e.emit_map_elt_key(i, |e| key.encode(e)));
-                try!(e.emit_map_elt_val(i, |e| val.encode(e)));
+                e.emit_map_elt_key(i, |e| key.encode(e))?;
+                e.emit_map_elt_val(i, |e| val.encode(e))?;
                 i += 1;
             }
             Ok(())
@@ -88,8 +88,8 @@ impl<
         d.read_map(|d, len| {
             let mut map = BTreeMap::new();
             for i in 0..len {
-                let key = try!(d.read_map_elt_key(i, |d| Decodable::decode(d)));
-                let val = try!(d.read_map_elt_val(i, |d| Decodable::decode(d)));
+                let key = d.read_map_elt_key(i, |d| Decodable::decode(d))?;
+                let val = d.read_map_elt_val(i, |d| Decodable::decode(d))?;
                 map.insert(key, val);
             }
             Ok(map)
@@ -104,7 +104,7 @@ impl<
         s.emit_seq(self.len(), |s| {
             let mut i = 0;
             for e in self.iter() {
-                try!(s.emit_seq_elt(i, |s| e.encode(s)));
+                s.emit_seq_elt(i, |s| e.encode(s))?;
                 i += 1;
             }
             Ok(())
@@ -119,7 +119,7 @@ impl<
         d.read_seq(|d, len| {
             let mut set = BTreeSet::new();
             for i in 0..len {
-                set.insert(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
+                set.insert(d.read_seq_elt(i, |d| Decodable::decode(d))?);
             }
             Ok(set)
         })
@@ -134,8 +134,8 @@ impl<K, V> Encodable for HashMap<K, V>
         e.emit_map(self.len(), |e| {
             let mut i = 0;
             for (key, val) in self.iter() {
-                try!(e.emit_map_elt_key(i, |e| key.encode(e)));
-                try!(e.emit_map_elt_val(i, |e| val.encode(e)));
+                e.emit_map_elt_key(i, |e| key.encode(e))?;
+                e.emit_map_elt_val(i, |e| val.encode(e))?;
                 i += 1;
             }
             Ok(())
@@ -151,8 +151,8 @@ impl<K, V> Decodable for HashMap<K, V>
         d.read_map(|d, len| {
             let mut map = HashMap::with_capacity(cap_capacity::<(K, V)>(len));
             for i in 0..len {
-                let key = try!(d.read_map_elt_key(i, |d| Decodable::decode(d)));
-                let val = try!(d.read_map_elt_val(i, |d| Decodable::decode(d)));
+                let key = d.read_map_elt_key(i, |d| Decodable::decode(d))?;
+                let val = d.read_map_elt_val(i, |d| Decodable::decode(d))?;
                 map.insert(key, val);
             }
             Ok(map)
@@ -165,7 +165,7 @@ impl<T> Encodable for HashSet<T> where T: Encodable + Hash + Eq {
         s.emit_seq(self.len(), |s| {
             let mut i = 0;
             for e in self.iter() {
-                try!(s.emit_seq_elt(i, |s| e.encode(s)));
+                s.emit_seq_elt(i, |s| e.encode(s))?;
                 i += 1;
             }
             Ok(())
@@ -178,7 +178,7 @@ impl<T> Decodable for HashSet<T> where T: Decodable + Hash + Eq, {
         d.read_seq(|d, len| {
             let mut set = HashSet::with_capacity(cap_capacity::<T>(len));
             for i in 0..len {
-                set.insert(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
+                set.insert(d.read_seq_elt(i, |d| Decodable::decode(d))?);
             }
             Ok(set)
         })

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -134,9 +134,9 @@ impl FromHex for str {
             buf <<= 4;
 
             match byte {
-                b'A'...b'F' => buf |= byte - b'A' + 10,
-                b'a'...b'f' => buf |= byte - b'a' + 10,
-                b'0'...b'9' => buf |= byte - b'0',
+                b'A'..=b'F' => buf |= byte - b'A' + 10,
+                b'a'..=b'f' => buf |= byte - b'a' + 10,
+                b'0'..=b'9' => buf |= byte - b'0',
                 b' '|b'\r'|b'\n'|b'\t' => {
                     buf >>= 4;
                     continue

--- a/src/json.rs
+++ b/src/json.rs
@@ -1540,14 +1540,14 @@ impl<T: Iterator<Item = char>> Parser<T> {
 
                 // A leading '0' must be the only digit before the decimal point.
                 match self.ch_or_null() {
-                    '0' ... '9' => return self.error(InvalidNumber),
+                    '0' ..= '9' => return self.error(InvalidNumber),
                     _ => ()
                 }
             },
-            '1' ... '9' => {
+            '1' ..= '9' => {
                 while !self.eof() {
                     match self.ch_or_null() {
-                        c @ '0' ... '9' => {
+                        c @ '0' ..= '9' => {
                             macro_rules! try_or_invalid {
                                 ($e: expr) => {
                                     match $e {
@@ -1576,7 +1576,7 @@ impl<T: Iterator<Item = char>> Parser<T> {
 
         // Make sure a digit follows the decimal place.
         match self.ch_or_null() {
-            '0' ... '9' => (),
+            '0' ..= '9' => (),
              _ => return self.error(InvalidNumber)
         }
 
@@ -1584,7 +1584,7 @@ impl<T: Iterator<Item = char>> Parser<T> {
         let mut frac = 0.0;
         while !self.eof() {
             match self.ch_or_null() {
-                c @ '0' ... '9' => {
+                c @ '0' ..= '9' => {
                     dec /= 10.0;
                     frac += (((c as isize) - ('0' as isize)) as f64) * dec;
                     self.bump();
@@ -1613,12 +1613,12 @@ impl<T: Iterator<Item = char>> Parser<T> {
 
         // Make sure a digit follows the exponent place.
         match self.ch_or_null() {
-            '0' ... '9' => (),
+            '0' ..= '9' => (),
             _ => return self.error(InvalidNumber)
         }
         while !self.eof() {
             match self.ch_or_null() {
-                c @ '0' ... '9' => {
+                c @ '0' ..= '9' => {
                     exp *= 10;
                     exp += (c as usize) - ('0' as usize);
 
@@ -1644,9 +1644,9 @@ impl<T: Iterator<Item = char>> Parser<T> {
         while i < 4 {
             self.bump();
             n = match self.ch_or_null() {
-                c @ '0' ... '9' => n * 16 + ((c as u16) - ('0' as u16)),
-                c @ 'a' ... 'f' => n * 16 + (10 + (c as u16) - ('a' as u16)),
-                c @ 'A' ... 'F' => n * 16 + (10 + (c as u16) - ('A' as u16)),
+                c @ '0' ..= '9' => n * 16 + ((c as u16) - ('0' as u16)),
+                c @ 'a' ..= 'f' => n * 16 + (10 + (c as u16) - ('a' as u16)),
+                c @ 'A' ..= 'F' => n * 16 + (10 + (c as u16) - ('A' as u16)),
                 _ => return self.error(InvalidEscape)
             };
 
@@ -1677,13 +1677,13 @@ impl<T: Iterator<Item = char>> Parser<T> {
                     'r' => res.push('\r'),
                     't' => res.push('\t'),
                     'u' => match try!(self.decode_hex_escape()) {
-                        0xDC00 ... 0xDFFF => {
+                        0xDC00 ..= 0xDFFF => {
                             return self.error(LoneLeadingSurrogateInHexEscape)
                         }
 
                         // Non-BMP characters are encoded as a sequence of
                         // two hex escapes, representing UTF-16 surrogates.
-                        n1 @ 0xD800 ... 0xDBFF => {
+                        n1 @ 0xD800 ..= 0xDBFF => {
                             match (self.next_char(), self.next_char()) {
                                 (Some('\\'), Some('u')) => (),
                                 _ => return self.error(UnexpectedEndOfHexEscape),
@@ -1913,7 +1913,7 @@ impl<T: Iterator<Item = char>> Parser<T> {
             'n' => { self.parse_ident("ull", NullValue) }
             't' => { self.parse_ident("rue", BooleanValue(true)) }
             'f' => { self.parse_ident("alse", BooleanValue(false)) }
-            '0' ... '9' | '-' => self.parse_number(),
+            '0' ..= '9' | '-' => self.parse_number(),
             '"' => match self.parse_str() {
                 Ok(s) => StringValue(s),
                 Err(e) => Error(e),

--- a/src/json.rs
+++ b/src/json.rs
@@ -2587,8 +2587,6 @@ impl FromStr for Json {
 
 #[cfg(test)]
 mod tests {
-    use self::Animal::*;
-    use {Encodable, Decodable};
     use super::Json::*;
     use super::ErrorCode::*;
     use super::ParserError::*;
@@ -2596,55 +2594,10 @@ mod tests {
     use super::JsonEvent::*;
     use super::StackElement::*;
     use super::{Json, DecodeResult, DecoderError, JsonEvent, Parser,
-                StackElement, Stack, Decoder, Encoder, EncoderError};
+                StackElement, Stack, Decoder};
     use std::{i64, u64, f32, f64};
     use std::collections::BTreeMap;
     use std::string;
-
-    #[derive(RustcDecodable, Eq, PartialEq, Debug)]
-    struct OptionData {
-        opt: Option<usize>,
-    }
-
-    #[test]
-    fn test_decode_option_none() {
-        let s ="{}";
-        let obj: OptionData = super::decode(s).unwrap();
-        assert_eq!(obj, OptionData { opt: None });
-    }
-
-    #[test]
-    fn test_decode_option_some() {
-        let s = "{ \"opt\": 10 }";
-        let obj: OptionData = super::decode(s).unwrap();
-        assert_eq!(obj, OptionData { opt: Some(10) });
-    }
-
-    #[test]
-    fn test_decode_option_malformed() {
-        check_err::<OptionData>("{ \"opt\": [] }",
-                                ExpectedError("Number".to_string(), "[]".to_string()));
-        check_err::<OptionData>("{ \"opt\": false }",
-                                ExpectedError("Number".to_string(), "false".to_string()));
-    }
-
-    #[derive(PartialEq, RustcEncodable, RustcDecodable, Debug)]
-    enum Animal {
-        Dog,
-        Frog(string::String, isize)
-    }
-
-    #[derive(PartialEq, RustcEncodable, RustcDecodable, Debug)]
-    struct Inner {
-        a: (),
-        b: usize,
-        c: Vec<string::String>,
-    }
-
-    #[derive(PartialEq, RustcEncodable, RustcDecodable, Debug)]
-    struct Outer {
-        inner: Vec<Inner>,
-    }
 
     fn mk_object(items: &[(string::String, Json)]) -> Json {
         let mut d = BTreeMap::new();
@@ -2824,35 +2777,6 @@ mod tests {
         // printed in a different order.
         assert_eq!(a.clone(), a.to_string().parse().unwrap());
         assert_eq!(a.clone(), a.pretty().to_string().parse().unwrap());
-    }
-
-    #[test]
-    fn test_write_enum() {
-        let animal = Dog;
-        assert_eq!(
-            format!("{}", super::as_json(&animal)),
-            "\"Dog\""
-        );
-        assert_eq!(
-            format!("{}", super::as_pretty_json(&animal)),
-            "\"Dog\""
-        );
-
-        let animal = Frog("Henry".to_string(), 349);
-        assert_eq!(
-            format!("{}", super::as_json(&animal)),
-            "{\"variant\":\"Frog\",\"fields\":[\"Henry\",349]}"
-        );
-        assert_eq!(
-            format!("{}", super::as_pretty_json(&animal)),
-            "{\n  \
-               \"variant\": \"Frog\",\n  \
-               \"fields\": [\n    \
-                 \"Henry\",\n    \
-                 349\n  \
-               ]\n\
-             }"
-        );
     }
 
     macro_rules! check_encoder_for_simple {
@@ -3162,55 +3086,12 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_struct() {
-        let s = "{
-            \"inner\": [
-                { \"a\": null, \"b\": 2, \"c\": [\"abc\", \"xyz\"] }
-            ]
-        }";
-
-        let v: Outer = super::decode(s).unwrap();
-        assert_eq!(
-            v,
-            Outer {
-                inner: vec![
-                    Inner { a: (), b: 2, c: vec!["abc".to_string(), "xyz".to_string()] }
-                ]
-            }
-        );
-    }
-
-    #[derive(RustcDecodable)]
-    struct FloatStruct {
-        f: f64,
-        a: Vec<f64>
-    }
-    #[test]
-    fn test_decode_struct_with_nan() {
-        let s = "{\"f\":null,\"a\":[null,123]}";
-        let obj: FloatStruct = super::decode(s).unwrap();
-        assert!(obj.f.is_nan());
-        assert!(obj.a[0].is_nan());
-        assert_eq!(obj.a[1], 123f64);
-    }
-
-    #[test]
     fn test_decode_option() {
         let value: Option<string::String> = super::decode("null").unwrap();
         assert_eq!(value, None);
 
         let value: Option<string::String> = super::decode("\"jodhpurs\"").unwrap();
         assert_eq!(value, Some("jodhpurs".to_string()));
-    }
-
-    #[test]
-    fn test_decode_enum() {
-        let value: Animal = super::decode("\"Dog\"").unwrap();
-        assert_eq!(value, Dog);
-
-        let s = "{\"variant\":\"Frog\",\"fields\":[\"Henry\",349]}";
-        let value: Animal = super::decode(s).unwrap();
-        assert_eq!(value, Frog("Henry".to_string(), 349));
     }
 
     #[test]
@@ -3223,22 +3104,11 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_map() {
-        let s = "{\"a\": \"Dog\", \"b\": {\"variant\":\"Frog\",\
-                  \"fields\":[\"Henry\", 349]}}";
-        let mut map: BTreeMap<string::String, Animal> = super::decode(s).unwrap();
-
-        assert_eq!(map.remove(&"a".to_string()), Some(Dog));
-        assert_eq!(map.remove(&"b".to_string()), Some(Frog("Henry".to_string(), 349)));
-    }
-
-    #[test]
     fn test_multiline_errors() {
         assert_eq!(Json::from_str("{\n  \"foo\":\n \"bar\""),
             Err(SyntaxError(EOFWhileParsingObject, 3, 8)));
     }
 
-    #[derive(RustcDecodable)]
     #[allow(dead_code)]
     struct DecodeStruct {
         x: f64,
@@ -3246,54 +3116,6 @@ mod tests {
         z: string::String,
         w: Vec<DecodeStruct>
     }
-    #[derive(RustcDecodable)]
-    enum DecodeEnum {
-        A(f64),
-        B(string::String)
-    }
-    fn check_err<T: Decodable>(to_parse: &'static str, expected: DecoderError) {
-        let res: DecodeResult<T> = match Json::from_str(to_parse) {
-            Err(e) => Err(ParseError(e)),
-            Ok(json) => Decodable::decode(&mut Decoder::new(json))
-        };
-        match res {
-            Ok(_) => panic!("`{:?}` parsed & decoded ok, expecting error `{:?}`",
-                              to_parse, expected),
-            Err(ParseError(e)) => panic!("`{}` is not valid json: {:?}",
-                                           to_parse, e),
-            Err(e) => {
-                assert_eq!(e, expected);
-            }
-        }
-    }
-    #[test]
-    fn test_decode_errors_struct() {
-        check_err::<DecodeStruct>("[]", ExpectedError("Object".to_string(), "[]".to_string()));
-        check_err::<DecodeStruct>("{\"x\": true, \"y\": true, \"z\": \"\", \"w\": []}",
-                                  ExpectedError("Number".to_string(), "true".to_string()));
-        check_err::<DecodeStruct>("{\"x\": 1, \"y\": [], \"z\": \"\", \"w\": []}",
-                                  ExpectedError("Boolean".to_string(), "[]".to_string()));
-        check_err::<DecodeStruct>("{\"x\": 1, \"y\": true, \"z\": {}, \"w\": []}",
-                                  ExpectedError("String".to_string(), "{}".to_string()));
-        check_err::<DecodeStruct>("{\"x\": 1, \"y\": true, \"z\": \"\", \"w\": null}",
-                                  ExpectedError("Array".to_string(), "null".to_string()));
-        check_err::<DecodeStruct>("{\"x\": 1, \"y\": true, \"z\": \"\"}",
-                                  MissingFieldError("w".to_string()));
-    }
-    #[test]
-    fn test_decode_errors_enum() {
-        check_err::<DecodeEnum>("{}",
-                                MissingFieldError("variant".to_string()));
-        check_err::<DecodeEnum>("{\"variant\": 1}",
-                                ExpectedError("String".to_string(), "1".to_string()));
-        check_err::<DecodeEnum>("{\"variant\": \"A\"}",
-                                MissingFieldError("fields".to_string()));
-        check_err::<DecodeEnum>("{\"variant\": \"A\", \"fields\": null}",
-                                ExpectedError("Array".to_string(), "null".to_string()));
-        check_err::<DecodeEnum>("{\"variant\": \"C\", \"fields\": []}",
-                                UnknownVariantError("C".to_string()));
-    }
-
     #[test]
     fn test_find(){
         let json_value = Json::from_str("{\"dog\" : \"cat\"}").unwrap();
@@ -3548,24 +3370,6 @@ mod tests {
         };
         let mut decoder = Decoder::new(json_obj);
         let _hm: HashMap<usize, bool> = Decodable::decode(&mut decoder).unwrap();
-    }
-
-    #[test]
-    fn test_hashmap_with_enum_key() {
-        use std::collections::HashMap;
-        use json;
-        #[derive(RustcEncodable, Eq, Hash, PartialEq, RustcDecodable, Debug)]
-        enum Enum {
-            Foo,
-            #[allow(dead_code)]
-            Bar,
-        }
-        let mut map = HashMap::new();
-        map.insert(Enum::Foo, 0);
-        let result = json::encode(&map).unwrap();
-        assert_eq!(result, r#"{"Foo":0}"#);
-        let decoded: HashMap<Enum, _> = json::decode(&result).unwrap();
-        assert_eq!(map, decoded);
     }
 
     #[test]
@@ -3924,69 +3728,6 @@ mod tests {
         assert_eq!(Some(15).to_json(), I64(15));
         assert_eq!(Some(15 as u32).to_json(), U64(15));
         assert_eq!(None::<isize>.to_json(), Null);
-    }
-
-    #[test]
-    fn test_encode_hashmap_with_arbitrary_key() {
-        use std::collections::HashMap;
-        #[derive(PartialEq, Eq, Hash, RustcEncodable)]
-        struct ArbitraryType(u32);
-        let mut hm: HashMap<ArbitraryType, bool> = HashMap::new();
-        hm.insert(ArbitraryType(1), true);
-        let mut mem_buf = string::String::new();
-        let mut encoder = Encoder::new(&mut mem_buf);
-        let result = hm.encode(&mut encoder);
-        match result.err().unwrap() {
-            EncoderError::BadHashmapKey => (),
-            _ => panic!("expected bad hash map key")
-        }
-    }
-
-    #[test]
-    fn test_encode_decode_phantom_data() {
-        use std::marker::PhantomData;
-
-        #[derive(Debug, RustcDecodable, RustcEncodable, Eq, PartialEq)]
-        struct Foo<P> {
-            phantom_data: PhantomData<P>
-        }
-
-        let f: Foo<u8> = Foo {
-            phantom_data: PhantomData
-        };
-        let s = super::encode(&f).unwrap();
-        let d: Foo<u8> = super::decode(&s).unwrap();
-        assert_eq!(f, d);
-    }
-
-    #[test]
-    fn test_bad_json_stack_depleted() {
-        use json;
-        #[derive(Debug, RustcDecodable)]
-        enum ChatEvent {
-            Variant(i32)
-        }
-        let serialized = "{\"variant\": \"Variant\", \"fields\": []}";
-        let r: Result<ChatEvent, _> = json::decode(serialized);
-        assert!(r.unwrap_err() == EOF);
-    }
-
-    #[test]
-    fn fixed_length_array() {
-        #[derive(Debug, RustcDecodable, RustcEncodable, Eq, PartialEq)]
-        struct Foo {
-            a: [u8; 1],
-            b: [i32; 2],
-            c: [u64; 3],
-        }
-        let f = Foo {
-            a: [0],
-            b: [1, 2],
-            c: [3, 4, 5],
-        };
-        let s = super::encode(&f).unwrap();
-        let d = super::decode(&s).unwrap();
-        assert_eq!(f, d);
     }
 
     #[test]

--- a/src/json.rs
+++ b/src/json.rs
@@ -404,7 +404,7 @@ impl fmt::Debug for ErrorCode {
 
 impl StdError for DecoderError {
     fn description(&self) -> &str { "decoder error" }
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             DecoderError::ParseError(ref e) => Some(e),
             _ => None,
@@ -457,7 +457,7 @@ impl From<fmt::Error> for EncoderError {
 pub type EncodeResult<T> = Result<T, EncoderError>;
 pub type DecodeResult<T> = Result<T, DecoderError>;
 
-fn escape_str(wr: &mut fmt::Write, v: &str) -> EncodeResult<()> {
+fn escape_str(wr: &mut dyn fmt::Write, v: &str) -> EncodeResult<()> {
     wr.write_str("\"")?;
 
     let mut start = 0;
@@ -519,14 +519,14 @@ fn escape_str(wr: &mut fmt::Write, v: &str) -> EncodeResult<()> {
     Ok(())
 }
 
-fn escape_char(writer: &mut fmt::Write, v: char) -> EncodeResult<()> {
+fn escape_char(writer: &mut dyn fmt::Write, v: char) -> EncodeResult<()> {
     let mut buf = [0; 4];
     let _ = write!(&mut &mut buf[..], "{}", v);
     let buf = unsafe { str::from_utf8_unchecked(&buf[..v.len_utf8()]) };
     escape_str(writer, buf)
 }
 
-fn spaces(wr: &mut fmt::Write, n: u32) -> EncodeResult<()> {
+fn spaces(wr: &mut dyn fmt::Write, n: u32) -> EncodeResult<()> {
     let mut n = n as usize;
     const BUF: &'static str = "                ";
 
@@ -575,7 +575,7 @@ enum EncodingFormat {
 
 /// A structure for implementing serialization to JSON.
 pub struct Encoder<'a> {
-    writer: &'a mut (fmt::Write+'a),
+    writer: &'a mut dyn fmt::Write,
     format : EncodingFormat,
     is_emitting_map_key: bool,
 }
@@ -583,7 +583,7 @@ pub struct Encoder<'a> {
 impl<'a> Encoder<'a> {
     /// Creates a new encoder whose output will be written in human-readable
     /// JSON to the specified writer
-    pub fn new_pretty(writer: &'a mut fmt::Write) -> Encoder<'a> {
+    pub fn new_pretty(writer: &'a mut dyn fmt::Write) -> Encoder<'a> {
         Encoder {
             writer: writer,
             format: EncodingFormat::Pretty {
@@ -596,7 +596,7 @@ impl<'a> Encoder<'a> {
 
     /// Creates a new encoder whose output will be written in compact
     /// JSON to the specified writer
-    pub fn new(writer: &'a mut fmt::Write) -> Encoder<'a> {
+    pub fn new(writer: &'a mut dyn fmt::Write) -> Encoder<'a> {
         Encoder {
             writer: writer,
             format: EncodingFormat::Compact,
@@ -956,7 +956,7 @@ pub fn as_pretty_json<T: Encodable>(t: &T) -> AsPrettyJson<T> {
 
 impl Json {
     /// Decodes a json value from an `&mut io::Read`
-    pub fn from_reader(rdr: &mut io::Read) -> Result<Self, BuilderError> {
+    pub fn from_reader(rdr: &mut dyn io::Read) -> Result<Self, BuilderError> {
         let contents = {
             let mut c = Vec::new();
             rdr.read_to_end(&mut c)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/rustc-serialize/")]
 #![cfg_attr(test, deny(warnings))]
+#![deny(ellipsis_inclusive_range_patterns)]
 #![allow(trivial_numeric_casts)]
 #![cfg_attr(rust_build, feature(staged_api))]
 #![cfg_attr(rust_build, staged_api)]


### PR DESCRIPTION
I'm aware that this is officially deprecated.

This set of changes is prompted by having things that continue to require `rustc-serialize` in some capacity, and the desire as a vendor to ensure that `rustc-serialize` thus continues to be usable.

Fixing the tests is required to help us ensure it continues to be usable, because tests help identify when a mechanism breaks.

Alas, due to the derive macro's no longer seeming to exist, I've had to exorcise all tests that relied on those macros.

Some of these changes are also spurred on by the `lib.rs` explicit statement:
```
![cfg_attr(test, deny(warnings))]
```

Which for whatever reason doesn't adequately respond to `--cap-lints warn`.

If this change set is not valuable, or at least, if not all changes are deemed valuable, this PR may still be helpful for other linux vendors who have the same sort of concerns about demonstrable usability. 

If some changes in this are not quite up to standard, please ensure to give some sort of opportunity to rectify them before closing this PR.
