### PR TITLE
fix the `implied_bounds_entailment` lint

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1152,7 +1152,7 @@ impl<'a, T: ?Sized> Decodable for Cow<'a, T>
     where T: ToOwned, T::Owned: Decodable
 {
     #[inline]
-    fn decode<D: Decoder>(d: &mut D) -> Result<Cow<'static, T>, D::Error> {
+    fn decode<D: Decoder>(d: &mut D) -> Result<Cow<'a, T>, D::Error> {
         Ok(Cow::Owned(try!(Decodable::decode(d))))
     }
 }


### PR DESCRIPTION
Allows us to publish a patch version which still compiles after https://github.com/rust-lang/rust/pull/117984 fixes a type system soundness regression.